### PR TITLE
Add support to only print version and exit without installing

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This [pyenv](https://github.com/yyuu/pyenv) plugin to install the latest version
 
 ## Usage
 
-     pyenv install-latest [<`pyenv install` options>] [<version-prefix>]
+     pyenv install-latest [--print] [<`pyenv install` options>] [<version-prefix>]
 
 ## Installation
 
@@ -32,4 +32,8 @@ Install 2.7-based version of Python.
     Installing Python-2.7.12...
     Installed Python-2.7.12 to /home/username/.pyenv/versions/2.7.12
 
+Print, but not install the latest 2.7-based version of Python
 
+    $ pyenv install-latest --print 2.7
+    2.7.15
+    

--- a/bin/pyenv-install-latest
+++ b/bin/pyenv-install-latest
@@ -36,6 +36,13 @@ for arg; do
       pyenv-help install-latest
       exit 0
       ;;
+    --print)
+      shift
+      latest=$(get_version $1)
+      [[ -z $latest ]] && exit 1;
+      echo $latest
+      exit 0
+      ;;
     -*)
       install_args="$install_args $arg"
       shift


### PR DESCRIPTION
I added support for a `--print` argument, which will only print the latest version and exit, without installing. This is useful for scripting.