### PR TITLE
Fix version specification

### DIFF
--- a/bin/pyenv-install-latest
+++ b/bin/pyenv-install-latest
@@ -19,7 +19,8 @@ get_version() {
     | grep -vE "(^Available versions:|-src|dev|rc|alpha|beta|(a|b)[0-9]+)" \
     | grep -E "^\s*$query" \
     | sed 's/^\s\+//' \
-    | tail -1
+    | tail -1 \
+    | xargs
 }
 
 version() {

--- a/bin/pyenv-install-latest
+++ b/bin/pyenv-install-latest
@@ -17,7 +17,7 @@ get_version() {
   [[ -z $query ]] && query=$DEFAULT_QUERY
   pyenv install --list \
     | grep -vE "(^Available versions:|-src|dev|rc|alpha|beta|(a|b)[0-9]+)" \
-    | grep -E "^\s*$query" \
+    | grep -E "(^\s*$query\.)|(^\s*$query$)" \
     | sed 's/^\s\+//' \
     | tail -1 \
     | xargs

--- a/bin/pyenv-install-latest
+++ b/bin/pyenv-install-latest
@@ -3,7 +3,7 @@
 set -e
 [ -n "$PYENV_DEBUG" ] && set -b
 
-PYENV_INSTALL_LATEST_VERSION="0.2.0"
+PYENV_INSTALL_LATEST_VERSION="0.2.1"
 DEFAULT_QUERY="[0-9]"
 
 # Provide pyenv completions


### PR DESCRIPTION
This PR primarily fixes an issue where the specified version could be improperly modified in cases where there were versions that held additional digits.

For example, `3.1` would improperly map to `3.10.1` instead of the latest version of `3.1`

This PR also sneaks in a small whitespace fix.